### PR TITLE
Support custom types from other modules

### DIFF
--- a/src/EnumReview.elm
+++ b/src/EnumReview.elm
@@ -212,7 +212,7 @@ declarationVisitor : Node Declaration -> ModuleContext -> ( List (Error {}), Mod
 declarationVisitor declaration context =
     case findEnumCreate context.lookupTable declaration of
         Just ( function, list ) ->
-            case getTypeName function of
+            case getTypeName context.lookupTable function of
                 Nothing ->
                     ( [ Rule.error
                             { message = "Enum definition is missing a type annotation"
@@ -223,110 +223,10 @@ declarationVisitor declaration context =
                     , context
                     )
 
-                Just typeName ->
+                Just ( [], typeName ) ->
                     case Dict.get typeName context.localTypes of
-                        Just (ConstructorsWithoutArguments constructors) ->
-                            case getTuples list of
-                                Just tuples ->
-                                    let
-                                        missingConstructors =
-                                            tuples
-                                                |> List.map Tuple.second
-                                                |> Set.fromList
-                                                |> Set.diff constructors
-                                                |> Set.toList
-
-                                        duplicateConstructors =
-                                            tuples |> List.map Tuple.second |> duplicates
-
-                                        duplicateStrings =
-                                            tuples
-                                                |> List.filterMap
-                                                    (\( key, _ ) ->
-                                                        case key of
-                                                            String str ->
-                                                                Just str
-
-                                                            Int _ ->
-                                                                Nothing
-                                                    )
-                                                |> duplicates
-
-                                        duplicateInts =
-                                            tuples
-                                                |> List.filterMap
-                                                    (\( key, _ ) ->
-                                                        case key of
-                                                            Int int ->
-                                                                Just int
-
-                                                            String _ ->
-                                                                Nothing
-                                                    )
-                                                |> duplicates
-                                    in
-                                    if missingConstructors /= [] then
-                                        ( [ Rule.error
-                                                { message = "The list passed to Enum.create does not contain all the type constructors for `" ++ typeName ++ "`"
-                                                , details = "It is missing the following constructors:" :: missingConstructors
-                                                }
-                                                (Node.range function.declaration)
-                                          ]
-                                        , context
-                                        )
-
-                                    else if duplicateStrings /= [] then
-                                        ( [ Rule.error
-                                                { message = "The list passed to Enum.create contains duplicate Strings:"
-                                                , details = List.map (\str -> "\"" ++ str ++ "\"") duplicateStrings
-                                                }
-                                                (Node.range function.declaration)
-                                          ]
-                                        , context
-                                        )
-
-                                    else if duplicateInts /= [] then
-                                        ( [ Rule.error
-                                                { message = "The list passed to Enum.createInt contains duplicate Ints:"
-                                                , details = List.map String.fromInt duplicateInts
-                                                }
-                                                (Node.range function.declaration)
-                                          ]
-                                        , context
-                                        )
-
-                                    else if duplicateConstructors /= [] then
-                                        ( [ Rule.error
-                                                { message = "The list passed to Enum.create contains duplicate constructors:"
-                                                , details = duplicateConstructors
-                                                }
-                                                (Node.range function.declaration)
-                                          ]
-                                        , context
-                                        )
-
-                                    else
-                                        --valid
-                                        ( [], context )
-
-                                Nothing ->
-                                    --unexpected structure, couldn't find tuple list
-                                    ( [ Rule.error
-                                            { message = "Unexpected structure"
-                                            , details = [ ":(" ]
-                                            }
-                                            (Node.range function.declaration)
-                                      ]
-                                    , context
-                                    )
-
-                        Just ConstructorsWithArguments ->
-                            ( [ Rule.error
-                                    { message = "One of the variants of `" ++ typeName ++ "` has an argument"
-                                    , details = [ "Enum.create is intended to only be used with simple enum-like types" ]
-                                    }
-                                    (Node.range function.declaration)
-                              ]
+                        Just constructors_ ->
+                            ( foo (Node.range function.declaration) list typeName constructors_
                             , context
                             )
 
@@ -341,13 +241,128 @@ declarationVisitor declaration context =
                             , context
                             )
 
+                Just ( moduleName, typeName ) ->
+                    case Dict.get moduleName context.customTypes |> Maybe.andThen (Dict.get typeName) of
+                        Just constructors_ ->
+                            ( foo (Node.range function.declaration) list typeName constructors_
+                            , context
+                            )
+
+                        Nothing ->
+                            -- couldn't find type definition
+                            ( [ Rule.error
+                                    { message = "Couldn't find the type definition for `" ++ String.join "." moduleName ++ "." ++ typeName ++ "`"
+                                    , details = [ "Where did you hide it?" ]
+                                    }
+                                    (Node.range function.declaration)
+                              ]
+                            , context
+                            )
+
         Nothing ->
             -- ignore, not an Enum definition
             ( [], context )
 
 
-getTypeName : Expression.Function -> Maybe String
-getTypeName function =
+foo : Range -> Expression -> String -> Constructors -> List (Error {})
+foo functionRange list typeName constructors_ =
+    case constructors_ of
+        ConstructorsWithoutArguments constructors ->
+            case getTuples list of
+                Just tuples ->
+                    let
+                        missingConstructors =
+                            tuples
+                                |> List.map Tuple.second
+                                |> Set.fromList
+                                |> Set.diff constructors
+                                |> Set.toList
+
+                        duplicateConstructors =
+                            tuples |> List.map Tuple.second |> duplicates
+
+                        duplicateStrings =
+                            tuples
+                                |> List.filterMap
+                                    (\( key, _ ) ->
+                                        case key of
+                                            String str ->
+                                                Just str
+
+                                            Int _ ->
+                                                Nothing
+                                    )
+                                |> duplicates
+
+                        duplicateInts =
+                            tuples
+                                |> List.filterMap
+                                    (\( key, _ ) ->
+                                        case key of
+                                            Int int ->
+                                                Just int
+
+                                            String _ ->
+                                                Nothing
+                                    )
+                                |> duplicates
+                    in
+                    if missingConstructors /= [] then
+                        [ Rule.error
+                            { message = "The list passed to Enum.create does not contain all the type constructors for `" ++ typeName ++ "`"
+                            , details = "It is missing the following constructors:" :: missingConstructors
+                            }
+                            functionRange
+                        ]
+
+                    else if duplicateStrings /= [] then
+                        [ Rule.error
+                            { message = "The list passed to Enum.create contains duplicate Strings:"
+                            , details = List.map (\str -> "\"" ++ str ++ "\"") duplicateStrings
+                            }
+                            functionRange
+                        ]
+
+                    else if duplicateInts /= [] then
+                        [ Rule.error
+                            { message = "The list passed to Enum.createInt contains duplicate Ints:"
+                            , details = List.map String.fromInt duplicateInts
+                            }
+                            functionRange
+                        ]
+
+                    else if duplicateConstructors /= [] then
+                        [ Rule.error
+                            { message = "The list passed to Enum.create contains duplicate constructors:"
+                            , details = duplicateConstructors
+                            }
+                            functionRange
+                        ]
+
+                    else
+                        --valid
+                        []
+
+                Nothing ->
+                    --unexpected structure, couldn't find tuple list
+                    [ Rule.error
+                        { message = "Unexpected structure"
+                        , details = [ ":(" ]
+                        }
+                        functionRange
+                    ]
+
+        ConstructorsWithArguments ->
+            [ Rule.error
+                { message = "One of the variants of `" ++ typeName ++ "` has an argument"
+                , details = [ "Enum.create is intended to only be used with simple enum-like types" ]
+                }
+                functionRange
+            ]
+
+
+getTypeName : ModuleNameLookupTable -> Expression.Function -> Maybe ( ModuleName, String )
+getTypeName lookupTable function =
     function.signature
         |> Maybe.map (Node.value >> .typeAnnotation >> Node.value)
         |> Maybe.andThen
@@ -358,9 +373,9 @@ getTypeName function =
                             ( ( [], enumType ), TypeAnnotation.Typed parameter _ ) ->
                                 -- TODO Handle multiple ways of importing Enum/EnumInt
                                 if enumType == "Enum" || enumType == "EnumInt" then
-                                    case Node.value parameter of
-                                        ( [], typeName ) ->
-                                            Just typeName
+                                    case ModuleNameLookupTable.moduleNameFor lookupTable parameter of
+                                        Just moduleName ->
+                                            Just ( moduleName, Node.value parameter |> Tuple.second )
 
                                         _ ->
                                             Nothing

--- a/src/EnumReview.elm
+++ b/src/EnumReview.elm
@@ -25,14 +25,14 @@ rule =
         |> Rule.fromProjectRuleSchema
 
 
-moduleVisitor : Rule.ModuleRuleSchema {} Context -> Rule.ModuleRuleSchema { hasAtLeastOneVisitor : () } Context
+moduleVisitor : Rule.ModuleRuleSchema {} ModuleContext -> Rule.ModuleRuleSchema { hasAtLeastOneVisitor : () } ModuleContext
 moduleVisitor schema =
     schema
         |> Rule.withDeclarationListVisitor declarationListVisitor
         |> Rule.withDeclarationEnterVisitor declarationVisitor
 
 
-foldProjectContexts : Context -> Context -> Context
+foldProjectContexts : ProjectContext -> ProjectContext -> ProjectContext
 foldProjectContexts newContext previousContext =
     { customTypes = Dict.union newContext.customTypes previousContext.customTypes }
 
@@ -42,12 +42,17 @@ type Constructors
     | ConstructorsWithArguments
 
 
-type alias Context =
+type alias ProjectContext =
     { customTypes : Dict String Constructors
     }
 
 
-initialContext : Context
+type alias ModuleContext =
+    { customTypes : Dict String Constructors
+    }
+
+
+initialContext : ProjectContext
 initialContext =
     { customTypes = Dict.empty
     }
@@ -57,7 +62,7 @@ initialContext =
 -- DECLARATION LIST VISITOR
 
 
-declarationListVisitor : List (Node Declaration) -> Context -> ( List nothing, Context )
+declarationListVisitor : List (Node Declaration) -> ModuleContext -> ( List nothing, ModuleContext )
 declarationListVisitor declarations context =
     -- Here we wish to find the custom types that were defined in the module, and store them in the context.
     ( []
@@ -154,7 +159,7 @@ findEnumCreate declaration =
             Nothing
 
 
-declarationVisitor : Node Declaration -> Context -> ( List (Error {}), Context )
+declarationVisitor : Node Declaration -> ModuleContext -> ( List (Error {}), ModuleContext )
 declarationVisitor declaration context =
     case findEnumCreate declaration of
         Just ( function, list ) ->

--- a/src/EnumReview.elm
+++ b/src/EnumReview.elm
@@ -162,8 +162,8 @@ getTuple (Node _ value) =
             Nothing
 
 
-findEnumCreate : Node Declaration -> Maybe ( Function, Expression )
-findEnumCreate declaration =
+findEnumCreate : ModuleNameLookupTable -> Node Declaration -> Maybe ( Function, Expression )
+findEnumCreate lookupTable declaration =
     case Node.value declaration of
         Declaration.FunctionDeclaration function ->
             case function.declaration |> Node.value |> .expression |> Node.value of
@@ -190,7 +190,7 @@ findEnumCreate declaration =
 
 declarationVisitor : Node Declaration -> ModuleContext -> ( List (Error {}), ModuleContext )
 declarationVisitor declaration context =
-    case findEnumCreate declaration of
+    case findEnumCreate context.lookupTable declaration of
         Just ( function, list ) ->
             case getTypeName function of
                 Nothing ->

--- a/src/EnumReview.elm
+++ b/src/EnumReview.elm
@@ -9,6 +9,7 @@ import Elm.Syntax.Node as Node exposing (Node(..))
 import Elm.Syntax.Range exposing (Range)
 import Elm.Syntax.Type exposing (Type)
 import Elm.Syntax.TypeAnnotation as TypeAnnotation exposing (TypeAnnotation(..))
+import Review.ModuleNameLookupTable exposing (ModuleNameLookupTable)
 import Review.Rule as Rule exposing (Error, Rule)
 import Set exposing (Set)
 
@@ -36,11 +37,13 @@ moduleVisitor schema =
 fromProjectToModule : Rule.ContextCreator ProjectContext ModuleContext
 fromProjectToModule =
     Rule.initContextCreator
-        (\projectContext ->
-            { customTypes = projectContext.customTypes
+        (\lookupTable projectContext ->
+            { lookupTable = lookupTable
+            , customTypes = projectContext.customTypes
             , localTypes = Dict.empty
             }
         )
+        |> Rule.withModuleNameLookupTable
 
 
 fromModuleToProject : Rule.ContextCreator ModuleContext ProjectContext
@@ -72,7 +75,8 @@ type alias ProjectContext =
 
 
 type alias ModuleContext =
-    { customTypes : Dict ModuleName (Dict String Constructors)
+    { lookupTable : ModuleNameLookupTable
+    , customTypes : Dict ModuleName (Dict String Constructors)
     , localTypes : Dict String Constructors
     }
 

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -85,6 +85,25 @@ enum = Enum.create [ ]
                         ]
 
         --
+        , test "Enum is aliased" <|
+            \_ ->
+                """
+module A exposing (..)
+import Enum as E exposing (Enum)
+type Fruit = Apple | Banana | Mango
+enum : Enum Fruit
+enum = E.create [ ]
+"""
+                    |> Review.Test.run rule
+                    |> Review.Test.expectErrors
+                        [ Review.Test.error
+                            { message = "The list passed to Enum.create does not contain all the type constructors for `Fruit`"
+                            , details = [ "It is missing the following constructors:", "Apple", "Banana", "Mango" ]
+                            , under = """enum = E.create [ ]"""
+                            }
+                        ]
+
+        --
         , test "missing type signature" <|
             \_ ->
                 """

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -12,6 +12,7 @@ all =
             \_ ->
                 """
 module A exposing (..)
+import Enum
 type Fruit = Apple | Banana | Mango
 enum : Enum Fruit
 enum = Enum.create [ ("Apple", Apple), ("Banana", Banana), ("Mango", Mango) ]
@@ -24,6 +25,7 @@ enum = Enum.create [ ("Apple", Apple), ("Banana", Banana), ("Mango", Mango) ]
             \_ ->
                 """
 module A exposing (..)
+import Enum
 type Fruit = Apple | Banana | Mango
 enum : Enum Fruit
 enum = [ ("Apple", Apple), ("Banana", Banana), ("Mango", Mango) ] |> Enum.create
@@ -36,6 +38,7 @@ enum = [ ("Apple", Apple), ("Banana", Banana), ("Mango", Mango) ] |> Enum.create
             \_ ->
                 """
 module A exposing (..)
+import Enum
 type Fruit = Apple | Banana | Mango
 enum : EnumInt Fruit
 enum = Enum.createInt [ (1, Apple), (2, Banana), (3, Mango) ]
@@ -48,6 +51,7 @@ enum = Enum.createInt [ (1, Apple), (2, Banana), (3, Mango) ]
             \_ ->
                 """
 module A exposing (..)
+import Enum
 type Fruit = Apple | Banana | Mango
 enum : EnumInt Fruit
 enum = Enum.createInt [ (1, Apple), (2, Banana), (2, Mango) ]
@@ -66,6 +70,7 @@ enum = Enum.createInt [ (1, Apple), (2, Banana), (2, Mango) ]
             \_ ->
                 """
 module A exposing (..)
+import Enum exposing (Enum)
 type Fruit = Apple | Banana | Mango
 enum : Enum Fruit
 enum = Enum.create [ ]
@@ -84,6 +89,7 @@ enum = Enum.create [ ]
             \_ ->
                 """
 module A exposing (..)
+import Enum exposing (Enum)
 type Fruit = Apple | Banana | Mango
 enum = Enum.create [ ("Apple", Apple), ("Banana", Banana), ("Mango", Mango) ]
 """
@@ -117,6 +123,7 @@ enum = Enum.create [ ("Apple", Apple) ]
             \_ ->
                 """
 module A exposing (..)
+import Enum exposing (Enum)
 type Fruit = Apple | Banana | Mango
 enum : Enum Fruit
 enum = Enum.create [ ("Apple", Apple), ("Banana", Banana), ("Mango", Mango), ("Mango2", Mango) ]
@@ -135,6 +142,7 @@ enum = Enum.create [ ("Apple", Apple), ("Banana", Banana), ("Mango", Mango), ("M
             \_ ->
                 """
 module A exposing (..)
+import Enum exposing (Enum)
 type Fruit = Apple | Banana | Mango
 enum : Enum Fruit
 enum = Enum.create [ ("Apple", Apple), ("Banana", Banana), ("Banana", Mango) ]
@@ -153,6 +161,7 @@ enum = Enum.create [ ("Apple", Apple), ("Banana", Banana), ("Banana", Mango) ]
             \_ ->
                 """
 module A exposing (..)
+import Enum exposing (Enum)
 type Fruit = Apple | Banana | Mango
 enum : Enum Fruit
 enum = [ ("Apple", Apple), ("Banana", Banana) ] |> Enum.create
@@ -171,6 +180,7 @@ enum = [ ("Apple", Apple), ("Banana", Banana) ] |> Enum.create
             \_ ->
                 """
 module A exposing (..)
+import Enum exposing (Enum)
 type Fruit = Apple | Banana | Mango Int
 enum : Enum Fruit
 enum = Enum.create [ ("Apple", Apple), ("Banana", Banana), ("Mango", Mango 0) ]
@@ -193,6 +203,7 @@ type Fruit = Apple | Banana | Mango
 """
                 , """
 module B exposing (..)
+import Enum exposing (Enum)
 import A exposing (Fruit(..))
 enum : Enum Fruit
 enum = Enum.create [ ("Apple", Apple), ("Banana", Banana), ("Mango", Mango) ]


### PR DESCRIPTION
This includes
- Handling multiple ways of calling Enum.create (import Enum exposing (..), import Enum as E with E.create, ...). This still needs to be done in other locations, but this is a good start and can serve as an example for the rest.
- Support custom types from other modules. The main idea is to store which module a custom type came from, otherwise we wouldn't be able to distinguish between similarly custom types from different modules

Feel free to ask questions!